### PR TITLE
Fix NLTK Dataset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bespokeai-factcheck"
-version = "0.0.0"
+version = "0.0.1"
 description = "Hallucination Detection using BespokeLabs.AI's MiniCheck model."
 authors = [{ name = "Guardrails AI", email = "contact@guardrailsai.com" }, { name = "BespokeLabs.AI", email = "company@bespokelabs.ai" }]
 license = { file = "LICENSE" }

--- a/validator/main.py
+++ b/validator/main.py
@@ -13,9 +13,6 @@ import concurrent.futures
 from tenacity import retry, stop_after_attempt, wait_exponential
 from bespokelabs import BespokeLabs
 
-
-nltk.download('punkt', quiet=True)
-
 @register_validator(name="bespokelabs/bespoke_minicheck", data_type="string")
 class BespokeMiniCheck(Validator):
     """Validates that the LLM-generated text is supported by the provided

--- a/validator/post-install.py
+++ b/validator/post-install.py
@@ -1,2 +1,49 @@
-print("Reminder: Please set your BESPOKE_API_KEY environment variable.")
-print("If you don't have one, you can get it at https://console.bespokelabs.ai/")
+# Download nltk dataset
+def load_nltk_data():
+    import re
+    import nltk
+    from importlib.metadata import version
+
+    nltk_version = version("nltk")
+    nltk_breaking_version = "3.8.2" # The version where the dataset changed
+
+    def parse_major_minor_patch(version: str):
+        """Extract the major, minor, and patch version numbers from a version string."""
+        match = re.match(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.(0|[1-9]\d*))?(?:[-+][0-9A-Za-z-.]+)?$", version)
+        if match:
+            major = int(match.group(1))
+            minor = int(match.group(2))
+            patch = int(match.group(3)) if match.group(3) else 0  # Default to 0 if patch is not provided
+            return major, minor, patch
+        else:
+            raise ValueError(f"Invalid semantic version: '{version}'")
+
+    def install_pre_382_dataset():
+        try:
+            nltk.data.find("tokenizers/punkt")
+        except LookupError:
+            nltk.download("punkt")
+        
+    def install_post_382_dataset():
+        try:
+            nltk.data.find("tokenizers/punkt_tab")
+        except LookupError:
+            nltk.download("punkt_tab")
+
+    try:
+        target_major, target_minor, target_patch = parse_major_minor_patch(nltk_breaking_version)
+        major, minor, patch = parse_major_minor_patch(nltk_version)
+
+        if (major, minor, patch) >= (target_major, target_minor, target_patch):
+            install_post_382_dataset()
+        elif (major, minor, patch) < (target_major, target_minor, target_patch):
+            install_pre_382_dataset()
+    except Exception:
+        print((
+            "Error auto-installing nltk dataset, please install manually.\n"
+            "This can be done with:\n",
+            "Version < 3.8.2:\n import nltk\n nltk.download('punkt')",
+            "Version >= 3.8.2:\n import nltk\n nltk.download('punkt_tab')"
+        ))
+
+load_nltk_data()


### PR DESCRIPTION
Due to breaking change in >=3.8.2 a different nltk dataset is required. The post install step now conditionally checks this and downloads the appropriate one